### PR TITLE
feat(proxy): connection pooling and retry with exponential backoff

### DIFF
--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -269,6 +269,10 @@ mod tests {
                 timeout_seconds: 30,
                 connect_timeout_seconds: 5,
                 idle_timeout_seconds: 60,
+                pool_idle_timeout_seconds: 90,
+                pool_max_idle_per_host: 8,
+                max_retries: 3,
+                retry_backoff_base_ms: 100,
             },
             backends: vec![
                 Backend {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -20,6 +20,18 @@ pub struct Defaults {
     /// Idle timeout for streaming responses in seconds (default: 60).
     #[serde(default = "default_idle_timeout")]
     pub idle_timeout_seconds: u32,
+    /// Pool idle timeout in seconds (default: 90).
+    #[serde(default = "default_pool_idle_timeout")]
+    pub pool_idle_timeout_seconds: u32,
+    /// Max idle connections per host (default: 8).
+    #[serde(default = "default_pool_max_idle_per_host")]
+    pub pool_max_idle_per_host: u32,
+    /// Max retry attempts for connection errors (default: 3).
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+    /// Base backoff in milliseconds for retry (default: 100).
+    #[serde(default = "default_retry_backoff_base_ms")]
+    pub retry_backoff_base_ms: u64,
 }
 
 fn default_connect_timeout() -> u32 {
@@ -28,6 +40,22 @@ fn default_connect_timeout() -> u32 {
 
 fn default_idle_timeout() -> u32 {
     60
+}
+
+fn default_pool_idle_timeout() -> u32 {
+    90
+}
+
+fn default_pool_max_idle_per_host() -> u32 {
+    8
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+
+fn default_retry_backoff_base_ms() -> u64 {
+    100
 }
 
 /// Backend configuration for an API provider.
@@ -68,6 +96,10 @@ impl Default for Defaults {
             timeout_seconds: 30,
             connect_timeout_seconds: 5,
             idle_timeout_seconds: 60,
+            pool_idle_timeout_seconds: 90,
+            pool_max_idle_per_host: 8,
+            max_retries: 3,
+            retry_backoff_base_ms: 100,
         }
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod health;
+pub mod pool;
 pub mod router;
 pub mod shutdown;
 pub mod timeout;
@@ -19,6 +20,7 @@ use crate::backend::BackendState;
 use crate::config::ConfigStore;
 use crate::proxy::router::{build_router, RouterEngine};
 use crate::proxy::shutdown::ShutdownManager;
+use crate::proxy::pool::PoolConfig;
 use crate::proxy::timeout::TimeoutConfig;
 
 pub fn init_tracing() {
@@ -43,8 +45,9 @@ impl ProxyServer {
     pub fn new(config: ConfigStore) -> Result<Self, crate::backend::BackendError> {
         let addr = "127.0.0.1:8080".parse().expect("Invalid bind address");
         let timeout_config = TimeoutConfig::from(&config.get().defaults);
+        let pool_config = PoolConfig::from(&config.get().defaults);
         let backend_state = BackendState::from_config(config.get())?;
-        let router = RouterEngine::new(config, timeout_config, backend_state);
+        let router = RouterEngine::new(config, timeout_config, pool_config, backend_state);
         Ok(Self {
             addr,
             router,

--- a/src/proxy/pool.rs
+++ b/src/proxy/pool.rs
@@ -1,0 +1,80 @@
+//! Connection pool and retry configuration for upstream requests.
+
+use std::time::Duration;
+
+use crate::config::Defaults;
+
+/// Pool and retry configuration for upstream requests.
+#[derive(Debug, Clone, Copy)]
+pub struct PoolConfig {
+    /// Idle timeout for pooled connections.
+    pub pool_idle_timeout: Duration,
+    /// Max idle connections per host.
+    pub pool_max_idle_per_host: usize,
+    /// Max retry attempts for connection errors.
+    pub max_retries: u32,
+    /// Base backoff duration for retries.
+    pub retry_backoff_base: Duration,
+}
+
+impl PoolConfig {
+    /// Create a new pool configuration with explicit values.
+    pub fn new(
+        pool_idle_timeout_secs: u64,
+        pool_max_idle_per_host: usize,
+        max_retries: u32,
+        retry_backoff_base_ms: u64,
+    ) -> Self {
+        Self {
+            pool_idle_timeout: Duration::from_secs(pool_idle_timeout_secs),
+            pool_max_idle_per_host,
+            max_retries,
+            retry_backoff_base: Duration::from_millis(retry_backoff_base_ms),
+        }
+    }
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            pool_idle_timeout: Duration::from_secs(90),
+            pool_max_idle_per_host: 8,
+            max_retries: 3,
+            retry_backoff_base: Duration::from_millis(100),
+        }
+    }
+}
+
+impl From<&Defaults> for PoolConfig {
+    fn from(defaults: &Defaults) -> Self {
+        Self {
+            pool_idle_timeout: Duration::from_secs(defaults.pool_idle_timeout_seconds.into()),
+            pool_max_idle_per_host: defaults.pool_max_idle_per_host as usize,
+            max_retries: defaults.max_retries,
+            retry_backoff_base: Duration::from_millis(defaults.retry_backoff_base_ms),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_pool_config() {
+        let config = PoolConfig::default();
+        assert_eq!(config.pool_idle_timeout, Duration::from_secs(90));
+        assert_eq!(config.pool_max_idle_per_host, 8);
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.retry_backoff_base, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_custom_pool_config() {
+        let config = PoolConfig::new(10, 2, 5, 250);
+        assert_eq!(config.pool_idle_timeout, Duration::from_secs(10));
+        assert_eq!(config.pool_max_idle_per_host, 2);
+        assert_eq!(config.max_retries, 5);
+        assert_eq!(config.retry_backoff_base, Duration::from_millis(250));
+    }
+}

--- a/src/proxy/router.rs
+++ b/src/proxy/router.rs
@@ -11,6 +11,7 @@ use crate::backend::BackendState;
 use crate::config::ConfigStore;
 use crate::proxy::error::ErrorResponse;
 use crate::proxy::health::HealthHandler;
+use crate::proxy::pool::PoolConfig;
 use crate::proxy::timeout::TimeoutConfig;
 use crate::proxy::upstream::UpstreamClient;
 
@@ -27,11 +28,12 @@ impl RouterEngine {
     pub fn new(
         config: ConfigStore,
         timeout_config: TimeoutConfig,
+        pool_config: PoolConfig,
         backend_state: BackendState,
     ) -> Self {
         Self {
             health: Arc::new(HealthHandler::new()),
-            upstream: Arc::new(UpstreamClient::new(timeout_config)),
+            upstream: Arc::new(UpstreamClient::new(timeout_config, pool_config)),
             config,
             backend_state,
         }

--- a/src/proxy/timeout.rs
+++ b/src/proxy/timeout.rs
@@ -75,6 +75,10 @@ mod tests {
             timeout_seconds: 45,
             connect_timeout_seconds: 10,
             idle_timeout_seconds: 90,
+            pool_idle_timeout_seconds: 120,
+            pool_max_idle_per_host: 4,
+            max_retries: 2,
+            retry_backoff_base_ms: 150,
         };
 
         let config = TimeoutConfig::from(&defaults);

--- a/tests/config_loader.rs
+++ b/tests/config_loader.rs
@@ -10,6 +10,10 @@ fn test_config_default_values() {
     // Defaults
     assert_eq!(config.defaults.active, "claude");
     assert_eq!(config.defaults.timeout_seconds, 30);
+    assert_eq!(config.defaults.pool_idle_timeout_seconds, 90);
+    assert_eq!(config.defaults.pool_max_idle_per_host, 8);
+    assert_eq!(config.defaults.max_retries, 3);
+    assert_eq!(config.defaults.retry_backoff_base_ms, 100);
 
     // Should have exactly one backend
     assert_eq!(config.backends.len(), 1);
@@ -69,6 +73,10 @@ fn test_validation_fails_missing_active_backend() {
             timeout_seconds: 30,
             connect_timeout_seconds: 5,
             idle_timeout_seconds: 60,
+            pool_idle_timeout_seconds: 90,
+            pool_max_idle_per_host: 8,
+            max_retries: 3,
+            retry_backoff_base_ms: 100,
         },
         backends: vec![Backend::default()],
     };
@@ -252,6 +260,10 @@ fn test_validation_fails_unconfigured_active_backend() {
             timeout_seconds: 30,
             connect_timeout_seconds: 5,
             idle_timeout_seconds: 60,
+            pool_idle_timeout_seconds: 90,
+            pool_max_idle_per_host: 8,
+            max_retries: 3,
+            retry_backoff_base_ms: 100,
         },
         backends: vec![Backend {
             name: "unconfigured".to_string(),
@@ -287,6 +299,10 @@ fn test_configured_backends_filters_correctly() {
             timeout_seconds: 30,
             connect_timeout_seconds: 5,
             idle_timeout_seconds: 60,
+            pool_idle_timeout_seconds: 90,
+            pool_max_idle_per_host: 8,
+            max_retries: 3,
+            retry_backoff_base_ms: 100,
         },
         backends: vec![
             Backend {


### PR DESCRIPTION
## Summary
- Add configurable connection pool settings (`pool_idle_timeout_seconds`, `pool_max_idle_per_host`)
- Add retry configuration (`max_retries`, `retry_backoff_base_ms`)
- Implement retry loop with exponential backoff for connection and timeout errors
- Configure reqwest client with pool settings

Closes cl-7bj.4

## Test plan
- [x] All 60 tests pass
- [x] Connection pool settings configurable via config.json
- [x] Retry logic only triggers on connection/timeout errors, not HTTP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)