### PR TITLE
fix: detect Shift+Enter via macOS CGEvent for newline insertion

### DIFF
--- a/crates/term_input/src/macos_modifiers.rs
+++ b/crates/term_input/src/macos_modifiers.rs
@@ -1,7 +1,8 @@
 /// macOS-specific: query live keyboard modifier state via CoreGraphics.
 ///
-/// Allows detecting Option/Alt key even when the terminal emulator
-/// (e.g. Warp in alternate screen mode) does not send ESC prefix.
+/// Allows detecting Option/Alt and Shift keys even when the terminal emulator
+/// (e.g. Warp in alternate screen mode) does not send ESC prefix or
+/// kitty keyboard protocol sequences.
 
 #[cfg(target_os = "macos")]
 mod cg {
@@ -14,11 +15,21 @@ mod cg {
     const COMBINED_SESSION_STATE: u32 = 0;
     /// NX_ALTERNATEMASK / kCGEventFlagMaskAlternate
     const FLAG_MASK_ALTERNATE: u64 = 0x00080000;
+    /// NX_SHIFTMASK / kCGEventFlagMaskShift
+    const FLAG_MASK_SHIFT: u64 = 0x00020000;
+
+    fn flags() -> u64 {
+        unsafe { CGEventSourceFlagsState(COMBINED_SESSION_STATE) }
+    }
 
     /// Returns `true` if either Option/Alt key is currently held down.
     pub fn is_option_held() -> bool {
-        let flags = unsafe { CGEventSourceFlagsState(COMBINED_SESSION_STATE) };
-        (flags & FLAG_MASK_ALTERNATE) != 0
+        (flags() & FLAG_MASK_ALTERNATE) != 0
+    }
+
+    /// Returns `true` if either Shift key is currently held down.
+    pub fn is_shift_held() -> bool {
+        (flags() & FLAG_MASK_SHIFT) != 0
     }
 }
 
@@ -28,6 +39,19 @@ pub fn is_option_held() -> bool {
     #[cfg(target_os = "macos")]
     {
         cg::is_option_held()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Returns `true` if the Shift key is currently held down.
+/// On non-macOS platforms, always returns `false`.
+pub fn is_shift_held() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        cg::is_shift_held()
     }
     #[cfg(not(target_os = "macos"))]
     {


### PR DESCRIPTION
## Summary

- Shift+Enter didn't work in the wrapper: the real terminal never receives the kitty keyboard protocol request (`CSI > 1 u`) from Claude Code because it's consumed by the internal Alacritty emulator
- Added Shift key detection via `CGEventSourceFlagsState` on macOS (same approach as the Option+Backspace fix in d84d55b)
- When Enter is pressed with Shift held, raw bytes are replaced with `ESC[13;2u` (kitty keyboard protocol encoding), so Claude Code inserts a newline instead of submitting the prompt

## Test plan

- [ ] Launch AnyClaude, type text in Claude Code's prompt
- [ ] Press Shift+Enter — should insert a newline (not submit)
- [ ] Press Enter — should submit the prompt (unchanged behavior)
- [ ] Verify Option+Backspace still works as before

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)